### PR TITLE
Hatskier/passing config through env variable

### DIFF
--- a/Dockerfile.public
+++ b/Dockerfile.public
@@ -1,0 +1,32 @@
+# Docker container built using this Dockerfile
+# can be published to the public docker registry
+# But before running the container it must be configured to provide
+# the node config through REDSTONE_NODE_CONFIG environment variable
+
+FROM node:12.13-alpine
+
+RUN mkdir /app
+WORKDIR /app
+
+# Installing required npm packages
+COPY package.json package.json
+COPY yarn.lock yarn.lock
+RUN yarn
+
+# Copying all files
+COPY . .
+
+# Removing public files
+RUN rm -f .secrets
+RUN rm -f .experiments
+
+# Building app
+RUN yarn build
+
+# Setting production env variables
+ENV MODE=PROD
+ENV ENABLE_JSON_LOGS=true
+ENV PERFORMANCE_TRACKING_LABEL_PREFIX=public
+
+# Running redstone node
+CMD yarn start:prod --config-env REDSTONE_NODE_CONFIG

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { JWKInterface } from "arweave/node/lib/wallet";
+
 export interface Manifest {
   txId?: string; // note: this fiels is set by smart contract while downloading active manifest content
   interval: number;
@@ -110,7 +112,8 @@ export interface ArweaveTransactionTags {
 };
 
 export interface NodeConfig {
-  arweaveKeysFile: string;
+  arweaveKeysFile?: string;
+  arweaveKeysJWK?: JWKInterface; // it must be specified when we pass config through an env variable
   useManifestFromSmartContract?: boolean;
   addEvmSignature?: boolean;
   manifestFile: string;

--- a/tools/docker/docker-config-avalanche.js
+++ b/tools/docker/docker-config-avalanche.js
@@ -1,0 +1,3 @@
+const generateConfig = require("./generate-docker-running-config");
+
+generateConfig("../../.secrets/env-config-redstone-avalanche.json");

--- a/tools/docker/docker-config-rapid.js
+++ b/tools/docker/docker-config-rapid.js
@@ -1,0 +1,3 @@
+const generateConfig = require("./generate-docker-running-config");
+
+generateConfig("../../.secrets/env-config-redstone-rapid.json");

--- a/tools/docker/generate-docker-running-config.js
+++ b/tools/docker/generate-docker-running-config.js
@@ -1,0 +1,11 @@
+module.exports = function(configFile, envVarName = "REDSTONE_NODE_CONFIG") {
+  console.log("\n=== Environment variables ===");
+  const stringifiedConfig = JSON.stringify(require(configFile));
+  console.log(`${envVarName}='${stringifiedConfig}'`);
+
+  console.log("\n\n=== Node running command (for Docker) ===");
+  console.log(`yarn start:prod --config-env ${envVarName}`);
+
+  console.log("\n\n=== Node running command (locally) ===");
+  console.log(`${envVarName}='${stringifiedConfig}' yarn start --config-env ${envVarName}`);
+};


### PR DESCRIPTION
Implementation of a new way for passing config - through env variables. This way of handling config allows to run redstone-node using a public Docker image, which can be hosted on public registries (like https://hub.docker.com/ or https://gallery.ecr.aws).

Before running the redstone-node using the public docker image, node operators will need to configure their environment variable (e.g. `REDSTONE_NODE_CONFIG`). The env variable must store the stringified config JSON. To run the node node operator needs to pass `--config-env` cli param with the name of the env variable that stores the config. In this case node operator doesn't need to pass `--config` cli param.

The solution is backwards compatible, that's why `--config` param is still supported and has higher priority. But maybe we'll smoothly migrate to the new approach, removing support for the old one. (anyway, not in this PR :) )

This PR also contains the new dockerfile: `Dockerfile.public`, which allows to build a public redstone-node image.